### PR TITLE
fixed bug: missing balance values in the output csv file

### DIFF
--- a/balances.js
+++ b/balances.js
@@ -48,9 +48,10 @@ module.exports.createBalances = async data => {
 
     closingBalances.push({
       wallet: key,
-      tokenIds
+      tokenIds,
+      balance: tokenIds.length
     });
   }
 
-  return closingBalances.filter(b => b.tokenIds.length > 0);
+  return closingBalances.filter(b => b.balance > 0);
 };


### PR DESCRIPTION
The CSV output files don't have balance values in the cell.
It's because balances data from createBalances() doesn't have balance values.

Added
- balance: tokenIds.length

and removed duplicated tokenIds.length call
